### PR TITLE
Add Vitest and tests for flashcard generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ FlashGenius is a modern web application that uses AI to generate educational fla
 - `npm run lint` - Run ESLint
 - `npm run preview` - Preview the production build locally
 - `npm run mastra:dev` - Start the Mastra AI server
+- `npm test` - Run unit tests with Vitest
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "mastra:dev": "mastra dev",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.18",
@@ -37,6 +38,7 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.4",
     "typescript": "^5.8.3",
-    "vite": "^6.3.1"
+    "vite": "^6.3.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateFlashcards, mastraClient } from '../client';
+
+const mockAgent = {
+  generate: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // @ts-ignore
+  mastraClient.getAgent = vi.fn().mockReturnValue(mockAgent);
+});
+
+describe('generateFlashcards', () => {
+  it('parses flashcards from valid JSON response', async () => {
+    mockAgent.generate.mockResolvedValue({
+      text: '{"flashcards": [{"question":"Q1","answer":"A1"}]}'
+    });
+
+    const cards = await generateFlashcards({
+      topic: 'test',
+      difficulty: 'beginner',
+      cardCount: 1,
+    });
+
+    expect(cards).toEqual([
+      { question: 'Q1', answer: 'A1', difficulty: 'beginner' },
+    ]);
+  });
+
+  it('falls back to regex extraction when JSON parsing fails', async () => {
+    mockAgent.generate.mockResolvedValue({
+      text: "question: 'Q2' answer: 'A2'"
+    });
+
+    const cards = await generateFlashcards({
+      topic: 'test',
+      difficulty: 'beginner',
+      cardCount: 1,
+    });
+
+    expect(cards).toEqual([
+      { question: 'Q2', answer: 'A2', difficulty: 'beginner' },
+    ]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,4 +8,8 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  test: {
+    environment: 'node',
+    globals: true,
+  },
 })


### PR DESCRIPTION
## Summary
- add vitest setup in package.json and vite config
- document running tests in README
- test generateFlashcards function for JSON and regex parsing

## Testing
- `npm test` *(fails: vitest not found)*